### PR TITLE
ARM: dts: wt88047: Restore modem and pheripheral region

### DIFF
--- a/arch/arm/boot/dts/qcom/wt88047/msm8916-wt88047.dtsi
+++ b/arch/arm/boot/dts/qcom/wt88047/msm8916-wt88047.dtsi
@@ -34,6 +34,14 @@
                         /* status = "disabled"; */
                 };
 
+                modem_adsp_region@0 {
+                        reg = <0x0 0x86800000 0x0 0x05400000>;
+                };
+
+                pheripheral_region@0 {
+                        reg = <0x0 0x8bc00000 0x0 0x0600000>;
+                };
+
                 secure_region@0 {
                         /* status = "disabled"; */
                 };


### PR DESCRIPTION
* In attempt to fix modem reset issue on specific variant
* Freeing a bit of RAM for userspace

Change-Id: I660e2ae454127af078551cbefc12bc0c4f3dc50a